### PR TITLE
Fix CI: add PYTHONPATH for tests

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -23,6 +23,8 @@ jobs:
         run: |
           python tools/py_compiler.py --output compiled_py --package collected_package
       - name: Run tests
+        env:
+          PYTHONPATH: compiled_py
         run: python -m pytest -q
       - name: Build artifacts
         run: |


### PR DESCRIPTION
Ensure compiled_py is on PYTHONPATH during tests so generated package is importable (fixes failing workflow).